### PR TITLE
Added Popover component and Calendar popover component

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,54 @@ struct SomeView: View {
 }
 ```
 
+### Popover/tooltip
+
+The native SwiftUI Popover for iOS looks like a sheet which is different from the UIKit version.
+This component reuses UIKit `UIPopoverPresentationController` in swiftUI.
+
+Usage
+```swift
+import ComponentUI
+
+struct SomeView: View {
+	@State private var isPresented = false
+	
+	var body: some View {
+		Button("Popover/Tooltip") {
+			isPresented.toggle()
+		}
+		.nativePopover($isPresented) {
+			ActualPopoverDesignView()
+		}
+	}
+}
+```
+
+### Calendar Popover
+
+In SwiftUI, we use `DatePicker` and the drawback is in design as we are forced to have the triggering UI/button/label look like apple recomends(ie: there is no room to style the triggering UI as you want)
+This component allows you to have the calendar in a popover or tooltip style while giving you room to style your triggering button/label as you wish.
+
+Usage
+```swift
+import ComponentUI
+
+struct SomeView: View {
+@State private var isPresented = false
+@State private var selectedDate: Date = .now
+
+	var body: some View {
+		Button {
+			isPresented.toggle()
+		} label: {
+			Text("Style it as you wish")
+		}
+		.calendarPopover(for: .date, isPresented: $isPresented, selected: $selectedDate)
+	}
+}
+```
+> Note: this component is still limited in selecting the date range. But will be updated soon to allow all the range expressions
+
+
 > NOTE:
 > Built this project in a learning environment, can't credit all my sources but the internet has been good to having all this live

--- a/Sources/ComponentUI/CalendarPopover/CalendarPopover.swift
+++ b/Sources/ComponentUI/CalendarPopover/CalendarPopover.swift
@@ -24,9 +24,10 @@ extension View {
 		isPresented: Binding<Bool>,
 		selected: Binding<Date>,
 		/// Using `PartialRangeFrom` since I only need the users to set notification from now onward.
-		in dateRange: PartialRangeFrom<Date> = Date.now...
+		in dateRange: PartialRangeFrom<Date> = Date.now...,
+		arrowDirection: UIPopoverArrowDirection = .up
 	) -> some View {
-		self.nativePopover(isPresented: isPresented, arrowDirection: .unknown) {
+		self.nativePopover(isPresented: isPresented, arrowDirection: arrowDirection) {
 			CalendarPopover(display: displayedComponent, selected: selected, in: dateRange)
 		}
 	}

--- a/Sources/ComponentUI/CalendarPopover/CalendarPopover.swift
+++ b/Sources/ComponentUI/CalendarPopover/CalendarPopover.swift
@@ -1,0 +1,74 @@
+//
+//  CalendarPopover.swift
+//  ComponentUI
+//
+//  Created by Musoni nshuti Nicolas on 09/08/2025.
+//
+
+// Note: This is only available for iOS and iPad
+#if canImport(UIKit)
+import SwiftUI
+
+extension View {
+	/// Calendar Popover presented in a popover. The usage of DatePicker doesn't give much freedom on how to style the button that will present the date picker
+	/// This View Modifier allows you to style the triggering button however you want.
+	/// - Parameters:
+	///  - displayedComponents: `DatePickerComponents`
+	///  - isPresented: `Bool`
+	///  - selected: Date to update incase of any changes
+	///  - dateRange: Open Date range from a specific point. This does not accept a closed range or upto range, only from a specific date
+	/// - Returns: ViewBuilder
+	@ViewBuilder
+	public func calendarPopover(
+		for displayedComponent: DatePickerComponents,
+		isPresented: Binding<Bool>,
+		selected: Binding<Date>,
+		/// Using `PartialRangeFrom` since I only need the users to set notification from now onward.
+		in dateRange: PartialRangeFrom<Date> = Date.now...
+	) -> some View {
+		self.nativePopover(isPresented: isPresented, arrowDirection: .unknown) {
+			CalendarPopover(display: displayedComponent, selected: selected, in: dateRange)
+		}
+	}
+}
+
+struct CalendarPopover: View {
+	let displayedComponent: DatePickerComponents
+	@Binding var selected: Date
+	let dateRange: PartialRangeFrom<Date>
+	
+	init(display: DatePickerComponents, selected: Binding<Date>, in dateRange: PartialRangeFrom<Date>) {
+		self.displayedComponent = display
+		self._selected = selected
+		self.dateRange = dateRange
+	}
+	
+	var body: some View {
+		DatePicker("", selection: $selected, in: dateRange, displayedComponents: displayedComponent)
+			.applyPickerStyle(for: displayedComponent)
+			.labelsHidden()
+	}
+}
+
+private extension View {
+	/// Applies a graphical style for date-only pickers and a wheel style for time pickers.
+	/// This is done specifically to match the intended design
+	/// - Parameter components: `DatePickerComponents`
+	/// - Returns ViewBuilder
+	@ViewBuilder
+	func applyPickerStyle(for components: DatePickerComponents) -> some View {
+		if components == .date {
+			self.datePickerStyle(.graphical)
+		} else {
+			self.datePickerStyle(.wheel)
+		}
+	}
+}
+
+#Preview("Date Time Picker Popover") {
+	Group {
+		CalendarPopover(display: .date, selected: .constant(.now), in: Date.now...)
+		CalendarPopover(display: .hourAndMinute, selected: .constant(.now), in: Date.distantPast...)
+	}
+}
+#endif

--- a/Sources/ComponentUI/Popover/PopoverController.swift
+++ b/Sources/ComponentUI/Popover/PopoverController.swift
@@ -16,7 +16,7 @@ extension View {
 	@ViewBuilder
 	public func nativePopover<Content: View>(
 		isPresented: Binding<Bool>,
-		arrowDirection: UIPopoverArrowDirection,
+		arrowDirection: UIPopoverArrowDirection = .up,
 		@ViewBuilder content: @escaping () -> Content
 	) -> some View {
 		self

--- a/Sources/ComponentUI/Popover/PopoverController.swift
+++ b/Sources/ComponentUI/Popover/PopoverController.swift
@@ -1,0 +1,112 @@
+//
+//  PopoverController.swift
+//  ComponentUI
+//
+//  Created by Musoni nshuti Nicolas on 09/08/2025.
+//
+// Source: https://www.youtube.com/watch?v=5VPEcZy0FaQ
+
+/// This component is only for iOS and iPad, can't be used in macOS
+#if canImport(UIKit)
+import UIKit
+import SwiftUI
+
+/// Extending the popover to the view
+extension View {
+	@ViewBuilder
+	public func nativePopover<Content: View>(
+		isPresented: Binding<Bool>,
+		arrowDirection: UIPopoverArrowDirection,
+		@ViewBuilder content: @escaping () -> Content
+	) -> some View {
+		self
+			.background {
+				PopoverController(
+					isPresented: isPresented,
+					arrowDirection: arrowDirection,
+					content: content()
+				)
+			}
+	}
+}
+
+struct PopoverController<Content: View>: UIViewControllerRepresentable {
+	@Binding var isPresented: Bool
+	var arrowDirection: UIPopoverArrowDirection
+	var content: Content
+	
+	@State private var alreadyPresented: Bool = false
+	
+	func makeCoordinator() -> Coordinator {
+		return Coordinator(parent: self)
+	}
+	
+	func makeUIViewController(context: Context) -> UIViewController {
+		let controller = UIViewController()
+		controller.view.backgroundColor = .clear
+		return controller
+	}
+	
+	func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+		if alreadyPresented {
+			/// Updating SwiftUI view, when It's Changed
+			if let hostingController = uiViewController.presentedViewController as? PopoverHostingViewController<Content> {
+				hostingController.rootView = content
+				/// Updating View size when it's updated
+				/// Or you can define your own size in swiftUI view
+				hostingController.preferredContentSize = hostingController.view.intrinsicContentSize
+			}
+			/// Close view, if it's toggled Back
+			if isPresented == false {
+				uiViewController.dismiss(animated: true) {
+					self.alreadyPresented = false
+				}
+			}
+		} else {
+			if isPresented {
+				let controller = PopoverHostingViewController(rootView: content)
+				controller.view.backgroundColor = .clear
+				controller.modalPresentationStyle = .popover
+				controller.popoverPresentationController?.permittedArrowDirections = arrowDirection
+				// Connecting Delegate
+				controller.presentationController?.delegate = context.coordinator
+				controller.popoverPresentationController?.sourceView = uiViewController.view
+				uiViewController.present(controller, animated: true)
+			}
+		}
+	}
+	
+	class Coordinator: NSObject, UIPopoverPresentationControllerDelegate {
+		var parent: PopoverController
+		init(parent: PopoverController) {
+			self.parent = parent
+		}
+		
+		func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+			return .none
+		}
+		
+		/// Observing the status of the Popover
+		/// When it's dismissed updating the isPresented State
+		func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+			parent.isPresented = false
+		}
+		
+		/// When the popover is presented, updating the alreadyPresented state
+		func presentationController(_ presentationController: UIPresentationController, willPresentWithAdaptiveStyle style: UIModalPresentationStyle, transitionCoordinator: UIViewControllerTransitionCoordinator?) {
+			DispatchQueue.main.async {
+				self.parent.alreadyPresented = true
+			}
+		}
+	}
+}
+
+/// Custom Hosting Controller for wrapping to it's SwiftUI View Size
+class PopoverHostingViewController<Content: View>: UIHostingController<Content> {
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		preferredContentSize = view.intrinsicContentSize
+	}
+}
+
+#endif


### PR DESCRIPTION
### Description

This PR adds 2 components to this library

1. Tooltip
2. Calendar Popover

Mainly, I'm reusing the UIKit popover behavior in SwiftUI since the native popover in swiftUI behaves differently from 

### Screenshots
| **Tooltip** | **Calendar Popover** |
| --- | --- |
| <img width="300" alt="2 ContentView" src="https://github.com/user-attachments/assets/b46f0926-a071-4dc3-aede-bf0a1cac9fa3" /> | <img width="300" alt="2 ContentView" src="https://github.com/user-attachments/assets/7cb36c7c-19ec-43b3-9468-bfae898bb2e4" /> |

