### PR TITLE
TextWithLink Component Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Displays a string where specified substrings are styled as tappable hyperlinks. 
 
 Usage:
 ```swift
+import ComponentUI
 struct SomeView: View {
 	var body: some View {
 		TextWithLink(

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ struct SomeView: View {
 
 ### TextWithLink
 
-Displays a string where a specified substrings are styled as tappable hyperlinks. The links open in `Safari`. So when linking a url, make sure it is compatible/readable in Safari.
+Displays a string where specified substrings are styled as tappable hyperlinks. The links open in `Safari`, so when linking a url, make sure it is compatible/readable in Safari.
 
 > This is useful for creating legal disclaimers, terms & conditions notices, or any text where only part of the text should be interactive.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ struct SomeView: View {
 ```
 > Note: this component is still limited in selecting the date range. But will be updated soon to allow all the range expressions
 
+### TextWithLink
+
+Displays a string where a specified substrings are styled as tappable hyperlinks. The links open in `Safari`. So when linking a url, make sure it is compatible/readable in Safari.
+
+> This is useful for creating legal disclaimers, terms & conditions notices, or any text where only part of the text should be interactive.
+
+Usage:
+```swift
+struct SomeView: View {
+	var body: some View {
+		TextWithLink(
+			text: "By continuing, you agree to our Privacy Policy.",
+			links: [
+				"Privacy Policy.": "https://www.ibirori.rw"
+			],
+			highlightColor: .pink,
+			underlineStyle: .single
+		)
+	}
+}
+```
 
 > NOTE:
 > Built this project in a learning environment, can't credit all my sources but the internet has been good to having all this live

--- a/Sources/ComponentUI/TextWithLink/TextWithLink.swift
+++ b/Sources/ComponentUI/TextWithLink/TextWithLink.swift
@@ -8,22 +8,20 @@
 import SwiftUI
 
 public struct TextWithLink: View {
+	public typealias TextLink = [String: String]
 	let text: String
-	let linkText: String
-	let url: String
+	let links: TextLink
 	let highlightColor: Color
 	let underlineStyle: Text.LineStyle
 	
 	public init(
 		text: String,
-		linkText: String,
-		url: String,
+		links: TextLink,
 		highlightColor: Color = .blue,
 		underlineStyle: Text.LineStyle = .single
 	) {
 		self.text = text
-		self.linkText = linkText
-		self.url = url
+		self.links = links
 		self.highlightColor = highlightColor
 		self.underlineStyle = underlineStyle
 	}
@@ -35,11 +33,13 @@ public struct TextWithLink: View {
 	private func makeAttributedString() -> AttributedString {
 		var attributed = AttributedString(text)
 		
-		if let range = attributed.range(of: linkText) {
-			attributed[range].foregroundColor = highlightColor
-			attributed[range].underlineStyle = underlineStyle
-			if let url = URL(string: url) {
-				attributed[range].link = url
+		for (key, value) in links {
+			if let range = attributed.range(of: key) {
+				attributed[range].foregroundColor = highlightColor
+				attributed[range].underlineStyle = underlineStyle
+				if let url = URL(string: value) {
+					attributed[range].link = url
+				}
 			}
 		}
 		
@@ -51,11 +51,21 @@ public struct TextWithLink: View {
 	Group {
 		TextWithLink(
 			text: "By continuing, you agree to our Privacy Policy.",
-			linkText: "Privacy Policy.",
-			url: "https://www.google.com"
+			links: [
+				"Privacy Policy.": "https://www.google.com",
+				"By": "https://ibirori.com"
+			]
 		)
 		Spacer()
 			.frame(height: 20)
-		TextWithLink(text: "By continuing, you agree to our Privacy Policy.", linkText: "Privacy Policy.", url: "https://www.google.com", highlightColor: .gray, underlineStyle: .init(pattern: .dashDotDot, color: .red))
+		TextWithLink(
+			text: "By continuing, you agree to our Privacy Policy.",
+			links: [
+				"Privacy Policy.": "https://www.google.com",
+				"By": "https://ibirori.com"
+			],
+			highlightColor: .gray,
+			underlineStyle: .init(pattern: .dashDotDot, color: .red)
+		)
 	}
 }

--- a/Sources/ComponentUI/TextWithLink/TextWithLink.swift
+++ b/Sources/ComponentUI/TextWithLink/TextWithLink.swift
@@ -1,0 +1,61 @@
+//
+//  TextWithLink.swift
+//  ComponentUI
+//
+//  Created by Musoni nshuti Nicolas on 11/08/2025.
+//
+
+import SwiftUI
+
+public struct TextWithLink: View {
+	let text: String
+	let linkText: String
+	let url: String
+	let highlightColor: Color
+	let underlineStyle: Text.LineStyle
+	
+	public init(
+		text: String,
+		linkText: String,
+		url: String,
+		highlightColor: Color = .blue,
+		underlineStyle: Text.LineStyle = .single
+	) {
+		self.text = text
+		self.linkText = linkText
+		self.url = url
+		self.highlightColor = highlightColor
+		self.underlineStyle = underlineStyle
+	}
+	
+    public var body: some View {
+		Text(makeAttributedString())
+    }
+	
+	private func makeAttributedString() -> AttributedString {
+		var attributed = AttributedString(text)
+		
+		if let range = attributed.range(of: linkText) {
+			attributed[range].foregroundColor = highlightColor
+			attributed[range].underlineStyle = underlineStyle
+			if let url = URL(string: url) {
+				attributed[range].link = url
+			}
+		}
+		
+		return attributed
+	}
+}
+
+#Preview("Link text") {
+	Group {
+		TextWithLink(
+			text: "By continuing, you agree to our Privacy Policy.",
+			linkText: "Privacy Policy.",
+			url: "https://www.google.com"
+		)
+		Spacer()
+			.frame(height: 20)
+		TextWithLink(text: "By continuing, you agree to our Privacy Policy.", linkText: "Privacy Policy.", url: "https://www.google.com", highlightColor: .gray, underlineStyle: .init(pattern: .dashDotDot, color: .red))
+	}
+}


### PR DESCRIPTION
### Description

This PR implements `TextWithLink` component.

This is mostly used in legal where you have to provided an inline text that has a link to read in details.

### Screenshots

| **iOS** | **Mac** |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/688988a8-e84a-4e55-9d8b-1d011f87c293" width="300" /> | <img src="https://github.com/user-attachments/assets/46920b77-d571-48da-8a3c-6b5e83a89953" width="300" /> |
